### PR TITLE
Initiate conversation and seek help

### DIFF
--- a/components/ui/enhanced-location-selector.tsx
+++ b/components/ui/enhanced-location-selector.tsx
@@ -162,7 +162,7 @@ export function EnhancedLocationSelector({
           onBlur={handleBlur}
           placeholder={placeholder}
           className={cn(
-            "pl-10",
+            "pl-10 border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
             showDetectLocation && query ? "pr-20" : query ? "pr-12" : showDetectLocation ? "pr-12" : "pr-3"
           )}
         />

--- a/components/ui/search-autocomplete.tsx
+++ b/components/ui/search-autocomplete.tsx
@@ -173,7 +173,7 @@ export function SearchAutocomplete({
           onFocus={handleFocus}
           onBlur={handleBlur}
           placeholder={placeholder}
-          className="w-full px-4 py-2 pl-10 pr-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
+          className="w-full px-4 py-2 pl-10 pr-10 border-0 bg-transparent rounded-lg focus:ring-0 focus:outline-none"
         />
         
         <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />


### PR DESCRIPTION
Remove conflicting border styles from search bar components to fix a frontpage visual inconsistency.

The `SearchAutocomplete` had a hardcoded border, and `EnhancedLocationSelector` used default input borders, while the `SearchBar` container already provided a `shadow-lg` visual boundary. This PR ensures individual components are borderless and transparent, allowing the container to define the overall search bar appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-49a256f7-e3fe-437b-be9f-22fdc9045a60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49a256f7-e3fe-437b-be9f-22fdc9045a60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

